### PR TITLE
Fix gene list schema

### DIFF
--- a/sources/genelists.py
+++ b/sources/genelists.py
@@ -32,8 +32,7 @@ class GeneList(BaseModel):
     message: str
 
 
-class GeneListsSchema(BaseModel):
-    RootModel: list[GeneList]
+GeneListsSchema = RootModel[list[GeneList]]
 
 
 class Secrets(BaseSettings):


### PR DESCRIPTION
The custom gene lists are currently not functioning as expected.

```
Gene list config did not match expected schema: 1 validation error for GeneListsSchema
  Input should be a valid dictionary or instance of GeneListsSchema [type=model_type, input_value=[{'name': 'Table 3', 'mes... 'TSC2', 'VHL', 'WT1']}], input_type=list]
    For further information visit https://errors.pydantic.dev/2.12/v/model_type
```
