### PR TITLE
Fix version and year

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 FROM python:3.13.6-slim AS app
 COPY --from=builder /root/.local /root/.local
 COPY --from=builder /app/ /app/
+COPY --from=builder /usr/bin/git /usr/bin/git
 WORKDIR /app
 ENV PATH=/root/.local/bin:$PATH
 

--- a/config.py
+++ b/config.py
@@ -3,13 +3,14 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 from sources import *
-from util import get_release_tag
+from util import get_release_tag, get_release_year
 
 
 class Settings(BaseSettings):
     debug: bool = True
     port: int = 8080
     release_tag: str = Field(get_release_tag())
+    release_year: int = Field(get_release_year())
     disabled_sources: str = Field(default="", env="DISABLED_SOURCES")
 
     sources: List[type] = [

--- a/router.py
+++ b/router.py
@@ -28,6 +28,7 @@ def index(request: Request):
         {
             "request": request,
             "release_tag": settings.release_tag,
+            "release_year": settings.release_year
         }
     )
 

--- a/templates/base.html.jinja2
+++ b/templates/base.html.jinja2
@@ -68,7 +68,7 @@
     <footer class="footer mt-auto py-3 bg-light">
       <div class="container">
         <span class="text-muted">
-        Molclass v{{ release_tag }}&nbsp;&nbsp;2022-2024
+        Molclass v{{ release_tag }}&nbsp;&nbsp;2022-{{ release_year }}
         </span>
         {% block footer %}
         {% endblock %}

--- a/util.py
+++ b/util.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 import subprocess
@@ -70,3 +71,11 @@ def get_release_tag() -> str:
         json = resp.json()
         tag = json["tag_name"]
     return tag
+
+def get_release_year():
+    try:
+        result = subprocess.run(['git', 'log', '-1', "--format=%cd", "--date=format:%Y"], stdout=subprocess.PIPE)
+        year = int(result.stdout.decode().strip())
+    except (FileNotFoundError, ValueError):
+        year = datetime.datetime.now().year
+    return year


### PR DESCRIPTION
Since the version number displayed in the footer gets retrieved using git, git needs to be installed in the Docker image.

I also added a dynamic update for the year, using a similar mechanism.