### PR TITLE
Fix lovd/stuck on loading

### DIFF
--- a/router.py
+++ b/router.py
@@ -328,6 +328,8 @@ async def websocket_endpoint(websocket: WebSocket, search: str, db_session: Sess
             await send_log("Used all sources.", websocket)
 
         save_variant_normalized(search, consensus_variant, db_session)
+        print("[DEBUG] Closing websocket")
+        await websocket.close()
 
     except WebSocketDisconnect:
         print("[DEBUG] WebSocket disconnected")

--- a/sources/lovd.py
+++ b/sources/lovd.py
@@ -31,7 +31,6 @@ SUMMARY_TABLE_TEMPLATE = """
 class LOVD(Source):
     def set_entries(self):
         self.entries = {
-            ("gene", "gene_cdot"): self.gene_cdot,
             ("gene", "cdot"): self.gene_cdot,
         }
         return self.entries
@@ -54,6 +53,10 @@ class LOVD(Source):
         enc_cdot = urllib.parse.quote(cdot)
         query_url = f"https://databases.lovd.nl/shared/api/rest.php/variants/{enc_gene}?search_position={enc_cdot}&show_variant_effect=1&format=application/json"
         _, json = await self.async_get_json(query_url)
+        if isinstance(json, str):
+            self.html_text = f"No rows found for 'cdot', in addition LOVD reports the following: {json}"
+            self.found = False
+            return
         if not json:
             self.log_warning(f"No rows found for '{cdot}'")
             self.found = False

--- a/sources/lovd.py
+++ b/sources/lovd.py
@@ -54,7 +54,7 @@ class LOVD(Source):
         query_url = f"https://databases.lovd.nl/shared/api/rest.php/variants/{enc_gene}?search_position={enc_cdot}&show_variant_effect=1&format=application/json"
         _, json = await self.async_get_json(query_url)
         if isinstance(json, str):
-            self.html_text = f"No rows found for 'cdot', in addition LOVD reports the following: {json}"
+            self.html_text = f"Variant not found. LOVD reports the following: {json}"
             self.found = False
             return
         if not json:

--- a/sources/lovd.py
+++ b/sources/lovd.py
@@ -51,6 +51,7 @@ class LOVD(Source):
         cdot = self.variant["cdot"]
         enc_gene = urllib.parse.quote(gene)
         enc_cdot = urllib.parse.quote(cdot)
+        gene_url = f"https://databases.lovd.nl/shared/variants/{enc_gene}/unique"
         query_url = f"https://databases.lovd.nl/shared/api/rest.php/variants/{enc_gene}?search_position={enc_cdot}&show_variant_effect=1&format=application/json"
         _, json = await self.async_get_json(query_url)
         if isinstance(json, str):
@@ -61,12 +62,12 @@ class LOVD(Source):
             self.log_warning(f"No rows found for '{cdot}'")
             self.found = False
             self.html_text = "Variant not found"
+            self.html_links["gene"] = SourceURL("Gene", gene_url)
             return
 
         transcript = json[0]["position_mRNA"][0].split(":")[0]
         dbid = json[0]["Variant/DBID"]
 
-        gene_url = f"https://databases.lovd.nl/shared/variants/{enc_gene}/unique"
         transcript_url = f"https://databases.lovd.nl/shared/transcripts/{transcript}"
         variant_url = f"https://databases.lovd.nl/shared/variants/{enc_gene}?search_VariantOnGenome%2FDBID={dbid}"
 

--- a/sources/source_result.py
+++ b/sources/source_result.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import json
 import traceback
 
 import aiohttp
@@ -225,7 +226,11 @@ class Source:
         try:
             self.log_debug(f"get_json: {url}")
             async with self.session.get(url, *args, **kwargs) as response:
-                resp = await response.json()
+                resp = await response.read()
+                try:
+                    resp = await response.json()
+                except json.JSONDecodeError:
+                    resp = await response.text()
                 return response, resp
         except asyncio.TimeoutError:
             self.timeout = True


### PR DESCRIPTION
- Some cards get stuck showing a loading animation, this is because the source never sends anything to display and the websocket remains open indefinitely. The webwocket will now get closed after all iterations are done, so these card will no longer be shown as loading.
- lovd api sometimes returned text, rather than json. One case where this happens is when the queried gene is unknown. So we can still provide a link to the gene is the returned data is proper json.